### PR TITLE
feat: makes QuicP2p::Endpoint cloneable so that it can more easily be used across threads.

### DIFF
--- a/src/connection_deduplicator.rs
+++ b/src/connection_deduplicator.rs
@@ -7,6 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use std::sync::Arc;
 use std::{
     collections::{hash_map::Entry, HashMap},
     net::SocketAddr,
@@ -18,14 +19,15 @@ type Result<T = (), E = Error> = std::result::Result<T, E>;
 
 // Deduplicate multiple concurrent connect attempts to the same peer - they all will yield the
 // same `Connection` instead of opening a separate connection each.
+#[derive(Clone)]
 pub(crate) struct ConnectionDeduplicator {
-    map: Mutex<HashMap<SocketAddr, broadcast::Sender<Result>>>,
+    map: Arc<Mutex<HashMap<SocketAddr, broadcast::Sender<Result>>>>,
 }
 
 impl ConnectionDeduplicator {
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(HashMap::new()),
+            map: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -64,6 +64,7 @@ impl DisconnectionEvents {
 
 /// Endpoint instance which can be used to create connections to peers,
 /// and listen to incoming messages from other peers.
+#[derive(Clone)]
 pub struct Endpoint {
     local_addr: SocketAddr,
     public_addr: Option<SocketAddr>,


### PR DESCRIPTION
* modifies ConnectionDeduplicator to use Arc<Mutex<\_>> instead of Mutex<\_>
* makes ConnectionDeduplicator cloneable

**Motivation:**

In brb_node_qp2p we have a listening thread and a sending thread that operate on the same Endpoint.   However Endpoint was not cloneable previously, so we had to use Arc<Mutex<Endpoint>> inside a local _SharedEndpoint_ struct.

This PR eliminates the need for _SharedEndpoint_ as we can just call clone() on QuicP2p::Endpoint directly.  tested, and it works great.